### PR TITLE
Improve test for Task 7 - update or new record

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -40,6 +40,7 @@ class UserController extends Controller
     {
         // TASK: find a user by $name and update it with $email
         //   if not found, create a user with $name, $email and random password
+        // NOTE: use bcrypt or Hash::make to make the password
         $user = NULL; // updated or created user
 
         return view('users.show', compact('user'));

--- a/tests/Feature/EloquentTest.php
+++ b/tests/Feature/EloquentTest.php
@@ -99,10 +99,16 @@ class EloquentTest extends TestCase
             'email' => 'john@john.com'
         ]);
 
-        // Same parameters - should NOT create a new user
+        // Let's check if the password is going to change
+        $userPassword = User::value('password');
+
+        // Same name - should NOT create a new user
         $this->get('users/check_update/john/john2@john.com');
+        $this->assertDatabaseCount('users', 1);
         $this->assertDatabaseHas('users', [
             'name' => 'john',
+            // Let's check if the password has changed
+            'password' => $userPassword,
             'email' => 'john2@john.com'
         ]);
     }


### PR DESCRIPTION
Dear Mr. Povilas,

this PR improves Test 7 which otherwise may be solved with both

```
$password = bcrypt('password');
$user = User::updateOrCreate(compact('name', 'email'), compact('password'));
```

and

```
$password = bcrypt('password');
$user = User::updateOrCreate(compact('name'), compact('email', 'password'));
```

which should not be accepted, according to the task.